### PR TITLE
fix: export schema DEFAULT values and CRLF line endings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,14 +277,35 @@ npm test    # 199 test (context detection + projectSync/snippet + formatter)
 - `T-SQL: Export Schema` komutu — Command Palette + Database node context menü
 - Tüm DB nesnelerini (Table, View, SP, Function, Trigger) seçilen klasöre `.sql` dosyaları olarak export eder
 - Klasör yapısı: `<hedef>/dbo/{Tables,Views,Stored Procedures,Functions,Triggers}/<Name>.sql`
-- Cache-first: tüm scriptler `schemaCache`'ten alınır (DB sorgusu yok), ~1sn'de 1700+ nesne
-- TABLE scriptleri cache'teki columns/indexes/FK/triggers'tan üretilir
-- VIEW/SP/Function/Trigger tanımları `loadObjectDefinitions()` ile toplu cache'lenir, CREATE OR ALTER dönüşümü yapılmaz
-- İdempotent write: mevcut dosya ile byte-for-byte karşılaştırma, aynıysa yazmaz (git diff oluşmaz)
-- CRLF → LF + trailing whitespace normalize
+- Export öncesi schema cache tamamen yenilenir (`refresh()` + `loadObjectDefinitions()`) — her zaman güncel DB verisi
 - Cancel desteği (her nesne öncesi kontrol)
 - Tree context menüden geldiğinde `connectionManager` bağlı değilse otomatik bağlanır
 - Output Channel'a (`T-SQL Connection`) başlangıç/bitiş zamanı ve sonuç loglanır
+
+#### Export Kuralları — Nesne Tipleri
+
+| Nesne Tipi | Export Yöntemi |
+|-----------|---------------|
+| **TABLE** | Cache'ten SSDT formatında üretilir (`buildTableScriptFromCache`) |
+| **VIEW / SP / FUNCTION / TRIGGER** | `OBJECT_DEFINITION()` ile DB'den aynen çekilir — format değiştirilmez |
+
+#### TABLE Export Formatı (SSDT Uyumlu)
+
+- **Kolon formatı:** `[ColName]` + UPPERCASE unbracketed datatype + precision (`DATETIME2 (7)`, `NVARCHAR (250)`) + hizalı padding
+- **Computed columns:** `[ColName] AS (expression)` formatında, PERSISTED varsa eklenir
+- **IDENTITY:** `IDENTITY (1, 1)` (boşluklu)
+- **DEFAULT:** Named constraint varsa `CONSTRAINT [DcName] DEFAULT (value)`, yoksa sadece `DEFAULT (value)`
+- **PK:** CREATE TABLE içinde inline (`CONSTRAINT [PkName] PRIMARY KEY CLUSTERED ([Col] ASC)`)
+- **FK:** CREATE TABLE içinde inline, cascade bilgisi dahil (`ON DELETE CASCADE`, `ON DELETE SET NULL` vb.)
+- **Index:** Ayrı `CREATE INDEX` statement'ları, SSDT formatında (`[Col] ASC/DESC`), filtered index WHERE clause dahil. Sıralama: mevcut dosya varsa dosyadaki sıra korunur, yeni dosyada DB creation order (`index_id`)
+- **Trigger:** Ayrı statement olarak dosya sonunda, DB'den aynen çekilir
+
+#### Export Dosya Formatı
+
+- **Encoding:** UTF-8 BOM
+- **Line ending:** CRLF (Windows/SSDT standardı)
+- **Trailing:** Dosya sonunda 1 boş satır
+- **İdempotent write:** Karşılaştırmada BOM, LF/CRLF ve trailing newline farkları yoksayılır — sadece içerik farkında yazılır
 
 ### Project Sync (DDL → SQL Project)
 

--- a/src/cache/schemaCache.ts
+++ b/src/cache/schemaCache.ts
@@ -21,6 +21,12 @@ export interface ColumnInfo {
     isIdentity?: boolean;
     hasDefault?: boolean;
     defaultValue?: string;
+    defaultConstraintName?: string;
+    numericPrecision?: number;
+    numericScale?: number;
+    datetimePrecision?: number;
+    computedDefinition?: string;
+    isPersisted?: boolean;
 }
 
 export interface ObjectInfo {
@@ -42,6 +48,7 @@ export interface IndexInfo {
     isUnique: boolean;
     isPrimaryKey: boolean;
     columns: string;
+    filterDefinition?: string;
 }
 
 export interface ForeignKeyInfo {
@@ -50,6 +57,8 @@ export interface ForeignKeyInfo {
     parentColumn: string;
     referencedTable: string;
     referencedColumn: string;
+    deleteAction?: string;
+    updateAction?: string;
 }
 
 export class SchemaCache {
@@ -174,13 +183,20 @@ export class SchemaCache {
 
         const safe = dbName.replace(/\]/g, ']]');
         const result = await this.connectionManager.executeQuery(
-            `SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, CHARACTER_MAXIMUM_LENGTH, ORDINAL_POSITION,
-                    COLUMNPROPERTY(OBJECT_ID('[${safe}].dbo.' + TABLE_NAME), COLUMN_NAME, 'IsIdentity') AS IS_IDENTITY,
-                    CASE WHEN COLUMN_DEFAULT IS NOT NULL THEN 1 ELSE 0 END AS HAS_DEFAULT,
-                    COLUMN_DEFAULT
-             FROM [${safe}].INFORMATION_SCHEMA.COLUMNS
-             WHERE TABLE_NAME = @tableName
-             ORDER BY ORDINAL_POSITION`,
+            `SELECT c.COLUMN_NAME, c.DATA_TYPE, c.IS_NULLABLE, c.CHARACTER_MAXIMUM_LENGTH, c.ORDINAL_POSITION,
+                    c.NUMERIC_PRECISION, c.NUMERIC_SCALE, c.DATETIME_PRECISION,
+                    COLUMNPROPERTY(OBJECT_ID('[${safe}].dbo.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity') AS IS_IDENTITY,
+                    CASE WHEN c.COLUMN_DEFAULT IS NOT NULL THEN 1 ELSE 0 END AS HAS_DEFAULT,
+                    c.COLUMN_DEFAULT,
+                    dc.name AS DEFAULT_CONSTRAINT_NAME,
+                    cc.definition AS COMPUTED_DEFINITION,
+                    cc.is_persisted AS IS_PERSISTED
+             FROM [${safe}].INFORMATION_SCHEMA.COLUMNS c
+             LEFT JOIN [${safe}].sys.columns sc ON sc.object_id = OBJECT_ID('[${safe}].dbo.' + c.TABLE_NAME) AND sc.name = c.COLUMN_NAME
+             LEFT JOIN [${safe}].sys.default_constraints dc ON sc.default_object_id = dc.object_id
+             LEFT JOIN [${safe}].sys.computed_columns cc ON sc.object_id = cc.object_id AND sc.column_id = cc.column_id
+             WHERE c.TABLE_NAME = @tableName
+             ORDER BY c.ORDINAL_POSITION`,
             { tableName: { type: TYPES.NVarChar, value: tableName } }
         );
 
@@ -193,6 +209,12 @@ export class SchemaCache {
             isIdentity: row['IS_IDENTITY'] === 1,
             hasDefault: row['HAS_DEFAULT'] === 1,
             defaultValue: (row['COLUMN_DEFAULT'] as string) || undefined,
+            defaultConstraintName: (row['DEFAULT_CONSTRAINT_NAME'] as string) || undefined,
+            numericPrecision: row['NUMERIC_PRECISION'] as number | undefined,
+            numericScale: row['NUMERIC_SCALE'] as number | undefined,
+            datetimePrecision: row['DATETIME_PRECISION'] as number | undefined,
+            computedDefinition: (row['COMPUTED_DEFINITION'] as string) || undefined,
+            isPersisted: row['IS_PERSISTED'] === true || row['IS_PERSISTED'] === 1 || undefined,
         }));
         this.extraDbColumnsLoaded.add(cacheKey);
         return obj.columns;
@@ -286,6 +308,12 @@ export class SchemaCache {
                 isIdentity: row['IS_IDENTITY'] === 1,
                 hasDefault: row['HAS_DEFAULT'] === 1,
                 defaultValue: (row['COLUMN_DEFAULT'] as string) || undefined,
+            defaultConstraintName: (row['DEFAULT_CONSTRAINT_NAME'] as string) || undefined,
+                numericPrecision: row['NUMERIC_PRECISION'] as number | undefined,
+                numericScale: row['NUMERIC_SCALE'] as number | undefined,
+                datetimePrecision: row['DATETIME_PRECISION'] as number | undefined,
+            computedDefinition: (row['COMPUTED_DEFINITION'] as string) || undefined,
+            isPersisted: row['IS_PERSISTED'] === true || row['IS_PERSISTED'] === 1 || undefined,
             });
 
             this.columnsLoaded.add(tableName);
@@ -325,6 +353,12 @@ export class SchemaCache {
             isIdentity: row['IS_IDENTITY'] === 1,
             hasDefault: row['HAS_DEFAULT'] === 1,
             defaultValue: (row['COLUMN_DEFAULT'] as string) || undefined,
+            defaultConstraintName: (row['DEFAULT_CONSTRAINT_NAME'] as string) || undefined,
+            numericPrecision: row['NUMERIC_PRECISION'] as number | undefined,
+            numericScale: row['NUMERIC_SCALE'] as number | undefined,
+            datetimePrecision: row['DATETIME_PRECISION'] as number | undefined,
+            computedDefinition: (row['COMPUTED_DEFINITION'] as string) || undefined,
+            isPersisted: row['IS_PERSISTED'] === true || row['IS_PERSISTED'] === 1 || undefined,
         }));
 
         this.columnsLoaded.add(key);
@@ -373,6 +407,8 @@ export class SchemaCache {
             parentColumn: row['PARENT_COLUMN'] as string,
             referencedTable: row['REFERENCED_TABLE'] as string,
             referencedColumn: row['REFERENCED_COLUMN'] as string,
+            deleteAction: row['DELETE_ACTION'] as string | undefined,
+            updateAction: row['UPDATE_ACTION'] as string | undefined,
         }));
         this.fkLoaded = true;
         this.log.appendLine(`[${ts()}] Foreign keys loaded: ${this.foreignKeys.length} relations (${Date.now() - start}ms)`);
@@ -448,6 +484,7 @@ export class SchemaCache {
                 isUnique: row['IS_UNIQUE'] as boolean,
                 isPrimaryKey: row['IS_PRIMARY_KEY'] as boolean,
                 columns: row['COLUMNS'] as string,
+                filterDefinition: (row['FILTER_DEFINITION'] as string) || undefined,
             };
 
             if (!this.indexes.has(tableName)) {

--- a/src/queries/schemaQueries.ts
+++ b/src/queries/schemaQueries.ts
@@ -18,26 +18,40 @@ ORDER BY ROUTINE_NAME;
 
 /** All columns (bulk load) */
 export const ALL_COLUMNS_QUERY = `
-SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE, IS_NULLABLE,
-       CHARACTER_MAXIMUM_LENGTH, ORDINAL_POSITION,
-       COLUMNPROPERTY(OBJECT_ID('dbo.' + TABLE_NAME), COLUMN_NAME, 'IsIdentity') AS IS_IDENTITY,
-       CASE WHEN COLUMN_DEFAULT IS NOT NULL THEN 1 ELSE 0 END AS HAS_DEFAULT,
-       COLUMN_DEFAULT
-FROM INFORMATION_SCHEMA.COLUMNS
-WHERE TABLE_SCHEMA = 'dbo'
-ORDER BY TABLE_NAME, ORDINAL_POSITION;
+SELECT c.TABLE_NAME, c.COLUMN_NAME, c.DATA_TYPE, c.IS_NULLABLE,
+       c.CHARACTER_MAXIMUM_LENGTH, c.ORDINAL_POSITION,
+       c.NUMERIC_PRECISION, c.NUMERIC_SCALE, c.DATETIME_PRECISION,
+       COLUMNPROPERTY(OBJECT_ID('dbo.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity') AS IS_IDENTITY,
+       CASE WHEN c.COLUMN_DEFAULT IS NOT NULL THEN 1 ELSE 0 END AS HAS_DEFAULT,
+       c.COLUMN_DEFAULT,
+       dc.name AS DEFAULT_CONSTRAINT_NAME,
+       cc.definition AS COMPUTED_DEFINITION,
+       cc.is_persisted AS IS_PERSISTED
+FROM INFORMATION_SCHEMA.COLUMNS c
+LEFT JOIN sys.columns sc ON sc.object_id = OBJECT_ID('dbo.' + c.TABLE_NAME) AND sc.name = c.COLUMN_NAME
+LEFT JOIN sys.default_constraints dc ON sc.default_object_id = dc.object_id
+LEFT JOIN sys.computed_columns cc ON sc.object_id = cc.object_id AND sc.column_id = cc.column_id
+WHERE c.TABLE_SCHEMA = 'dbo'
+ORDER BY c.TABLE_NAME, c.ORDINAL_POSITION;
 `;
 
 /** Columns for a specific table/view */
 export const TABLE_COLUMNS_QUERY = `
-SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE,
-       CHARACTER_MAXIMUM_LENGTH, ORDINAL_POSITION,
-       COLUMNPROPERTY(OBJECT_ID('dbo.' + TABLE_NAME), COLUMN_NAME, 'IsIdentity') AS IS_IDENTITY,
-       CASE WHEN COLUMN_DEFAULT IS NOT NULL THEN 1 ELSE 0 END AS HAS_DEFAULT,
-       COLUMN_DEFAULT
-FROM INFORMATION_SCHEMA.COLUMNS
-WHERE TABLE_SCHEMA = 'dbo' AND TABLE_NAME = @tableName
-ORDER BY ORDINAL_POSITION;
+SELECT c.COLUMN_NAME, c.DATA_TYPE, c.IS_NULLABLE,
+       c.CHARACTER_MAXIMUM_LENGTH, c.ORDINAL_POSITION,
+       c.NUMERIC_PRECISION, c.NUMERIC_SCALE, c.DATETIME_PRECISION,
+       COLUMNPROPERTY(OBJECT_ID('dbo.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity') AS IS_IDENTITY,
+       CASE WHEN c.COLUMN_DEFAULT IS NOT NULL THEN 1 ELSE 0 END AS HAS_DEFAULT,
+       c.COLUMN_DEFAULT,
+       dc.name AS DEFAULT_CONSTRAINT_NAME,
+       cc.definition AS COMPUTED_DEFINITION,
+       cc.is_persisted AS IS_PERSISTED
+FROM INFORMATION_SCHEMA.COLUMNS c
+LEFT JOIN sys.columns sc ON sc.object_id = OBJECT_ID('dbo.' + c.TABLE_NAME) AND sc.name = c.COLUMN_NAME
+LEFT JOIN sys.default_constraints dc ON sc.default_object_id = dc.object_id
+LEFT JOIN sys.computed_columns cc ON sc.object_id = cc.object_id AND sc.column_id = cc.column_id
+WHERE c.TABLE_SCHEMA = 'dbo' AND c.TABLE_NAME = @tableName
+ORDER BY c.ORDINAL_POSITION;
 `;
 
 /** SP/Function definition */
@@ -73,7 +87,9 @@ SELECT
     tp.name AS PARENT_TABLE,
     cp.name AS PARENT_COLUMN,
     tr.name AS REFERENCED_TABLE,
-    cr.name AS REFERENCED_COLUMN
+    cr.name AS REFERENCED_COLUMN,
+    fk.delete_referential_action_desc AS DELETE_ACTION,
+    fk.update_referential_action_desc AS UPDATE_ACTION
 FROM sys.foreign_keys fk
 INNER JOIN sys.foreign_key_columns fkc ON fk.object_id = fkc.constraint_object_id
 INNER JOIN sys.tables tp ON fkc.parent_object_id = tp.object_id
@@ -91,14 +107,15 @@ SELECT
     i.type_desc AS INDEX_TYPE,
     i.is_unique AS IS_UNIQUE,
     i.is_primary_key AS IS_PRIMARY_KEY,
-    STRING_AGG(c.name, ', ') WITHIN GROUP (ORDER BY ic.key_ordinal) AS COLUMNS
+    STRING_AGG('[' + c.name + ']' + CASE WHEN ic.is_descending_key = 1 THEN ' DESC' ELSE ' ASC' END, ', ') WITHIN GROUP (ORDER BY ic.key_ordinal) AS COLUMNS,
+    i.filter_definition AS FILTER_DEFINITION
 FROM sys.indexes i
-INNER JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+INNER JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id AND ic.is_included_column = 0
 INNER JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id
 INNER JOIN sys.tables t ON i.object_id = t.object_id
 WHERE t.schema_id = SCHEMA_ID('dbo') AND i.name IS NOT NULL
-GROUP BY i.object_id, i.name, i.type_desc, i.is_unique, i.is_primary_key
-ORDER BY TABLE_NAME, i.is_primary_key DESC, i.name;
+GROUP BY i.object_id, i.name, i.type_desc, i.is_unique, i.is_primary_key, i.filter_definition, i.index_id
+ORDER BY TABLE_NAME, i.is_primary_key DESC, i.index_id;
 `;
 
 /** SP parameters */

--- a/src/sync/schemaExporter.ts
+++ b/src/sync/schemaExporter.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ConnectionManager } from '../connection/connectionManager';
-import { SchemaCache, ObjectInfo } from '../cache/schemaCache';
+import { SchemaCache, ObjectInfo, ColumnInfo } from '../cache/schemaCache';
 import { ts } from '../utils/timestamp';
 
 const SUBDIRECTORY_MAP: Record<string, string> = {
@@ -13,17 +13,21 @@ const SUBDIRECTORY_MAP: Record<string, string> = {
     'TABLE': 'Tables',
 };
 
-/** Normalize line endings to CRLF and trim trailing whitespace for consistent git diffs */
+const BOM = '\uFEFF';
+
+/** Normalize line endings to CRLF, add BOM, and trim trailing whitespace for consistent git diffs */
 function normalizeScript(script: string): string {
-    let s = script.replace(/\r\n/g, '\n').replace(/[ \t]+$/gm, '').replace(/\n+$/, '');
-    s = s + '\n';
-    // Convert to CRLF (Windows/SSDT standard)
-    return s.replace(/\n/g, '\r\n');
+    // Strip existing BOM if present
+    let s = script.startsWith(BOM) ? script.slice(1) : script;
+    s = s.replace(/\r\n/g, '\n').replace(/[ \t]+$/gm, '').replace(/\n+$/, '');
+    s = s + '\n\n'; // trailing blank line (SSDT standard)
+    // Convert to CRLF (Windows/SSDT standard) and prepend BOM
+    return BOM + s.replace(/\n/g, '\r\n');
 }
 
-/** Strip line endings for content comparison (ignores LF vs CRLF difference) */
+/** Strip BOM, normalize line endings and trailing newlines for content comparison */
 function stripLineEndings(s: string): string {
-    return s.replace(/\r\n/g, '\n');
+    return s.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\n+$/, '\n');
 }
 
 /** Only write if content actually changed (idempotent) */
@@ -66,11 +70,10 @@ export class SchemaExporter {
         log.appendLine(`[${ts()}] [SchemaExporter] Export başladı — ${total} nesne → ${exportPath}`);
         log.show(true);
 
-        // Ensure object definitions are cached
-        if (!this.schemaCache.isFullyLoaded) {
-            log.appendLine(`[${ts()}] [SchemaExporter] Schema detayları yükleniyor...`);
-            await this.schemaCache.loadObjectDefinitions();
-        }
+        // Always refresh all schema data before export (columns, FKs, indexes, triggers, definitions)
+        log.appendLine(`[${ts()}] [SchemaExporter] Schema yenileniyor...`);
+        await this.schemaCache.refresh();
+        await this.schemaCache.loadObjectDefinitions();
 
         for (let i = 0; i < objects.length; i++) {
             if (token.isCancellationRequested) { break; }
@@ -82,12 +85,12 @@ export class SchemaExporter {
             });
 
             try {
-                const script = this.getScript(obj);
+                const subDir = SUBDIRECTORY_MAP[obj.type] || obj.type;
+                const filePath = path.join(exportPath, 'dbo', subDir, `${obj.name}.sql`);
+                const script = this.getScript(obj, filePath);
                 if (!script) { skipped++; continue; }
 
                 const normalized = normalizeScript(script);
-                const subDir = SUBDIRECTORY_MAP[obj.type] || obj.type;
-                const filePath = path.join(exportPath, 'dbo', subDir, `${obj.name}.sql`);
 
                 if (writeIfChanged(filePath, normalized)) {
                     written++;
@@ -106,69 +109,154 @@ export class SchemaExporter {
         return { written, skipped, errors };
     }
 
-    private getScript(obj: ObjectInfo): string | null {
+    private getScript(obj: ObjectInfo, existingFilePath?: string): string | null {
         if (obj.type === 'TABLE') {
-            return this.buildTableScriptFromCache(obj.name);
+            return this.buildTableScriptFromCache(obj.name, existingFilePath);
         }
 
         // VIEW / SP / FUNCTION / TRIGGER — cache'ten al
         return this.schemaCache.getObjectDefinition(obj.name) || null;
     }
 
-    /** Build CREATE TABLE script from cached schema data */
-    private buildTableScriptFromCache(tableName: string): string | null {
+    /** Format data type in SSDT style: UPPERCASE, unbracketed, with precision */
+    private formatDataType(col: ColumnInfo): string {
+        const dt = col.dataType.toLowerCase();
+        const upper = col.dataType.toUpperCase();
+
+        // String/binary types: NVARCHAR (250), VARCHAR (MAX)
+        if (['varchar', 'nvarchar', 'char', 'nchar', 'varbinary', 'binary'].includes(dt)) {
+            const len = col.maxLength === -1 ? 'MAX' : String(col.maxLength);
+            return `${upper} (${len})`;
+        }
+        // Numeric types with precision: DECIMAL (18, 2)
+        if (['decimal', 'numeric'].includes(dt) && col.numericPrecision != null) {
+            return `${upper} (${col.numericPrecision}, ${col.numericScale ?? 0})`;
+        }
+        // Datetime types with precision: DATETIME2 (7)
+        if (['datetime2', 'datetimeoffset', 'time'].includes(dt) && col.datetimePrecision != null) {
+            return `${upper} (${col.datetimePrecision})`;
+        }
+        return upper;
+    }
+
+    /** Extract index names from existing file to preserve ordering */
+    private getExistingIndexOrder(filePath: string): string[] {
+        if (!fs.existsSync(filePath)) { return []; }
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const order: string[] = [];
+        const re = /CREATE\s+(?:UNIQUE\s+)?(?:CLUSTERED|NONCLUSTERED)\s+INDEX\s+\[([^\]]+)\]/gi;
+        let m;
+        while ((m = re.exec(content)) !== null) {
+            order.push(m[1]);
+        }
+        return order;
+    }
+
+    /** Build CREATE TABLE script from cached schema data (SSDT format) */
+    private buildTableScriptFromCache(tableName: string, existingFilePath?: string): string | null {
         const obj = this.schemaCache.findObject(tableName);
         if (!obj?.columns || obj.columns.length === 0) { return null; }
 
-        const lines: string[] = [];
-        lines.push(`CREATE TABLE [dbo].[${tableName}]`, '(');
-
-        // Columns
-        for (let i = 0; i < obj.columns.length; i++) {
-            const col = obj.columns[i];
-            let colDef = `    [${col.name}]`;
-            colDef += ` [${col.dataType}]`;
-
-            if (['varchar', 'nvarchar', 'char', 'nchar', 'varbinary', 'binary'].includes(col.dataType)) {
-                colDef += col.maxLength === -1 ? '(MAX)' : `(${col.maxLength})`;
-            }
-
-            if (col.isIdentity) { colDef += ' IDENTITY(1,1)'; }
-            colDef += col.isNullable ? ' NULL' : ' NOT NULL';
-            if (col.hasDefault && col.defaultValue) { colDef += ` DEFAULT ${col.defaultValue}`; }
-
-            if (i < obj.columns.length - 1) { colDef += ','; }
-            lines.push(colDef);
-        }
-        lines.push(')');
-        lines.push('GO');
-
-        // Indexes & PK
         const indexes = this.schemaCache.getIndexes(tableName);
-        for (const idx of indexes) {
-            if (idx.isPrimaryKey) {
-                lines.push(`ALTER TABLE [dbo].[${tableName}] ADD CONSTRAINT [${idx.name}] PRIMARY KEY ${idx.type} (${idx.columns})`);
-            } else {
-                const unique = idx.isUnique ? 'UNIQUE ' : '';
-                lines.push(`CREATE ${unique}${idx.type} INDEX [${idx.name}] ON [dbo].[${tableName}] (${idx.columns})`);
-            }
-            lines.push('GO');
-        }
-
-        // Foreign keys
         const fks = this.schemaCache.getForeignKeysForTable(tableName)
             .filter(fk => fk.parentTable.toLowerCase() === tableName.toLowerCase());
-        for (const fk of fks) {
-            lines.push(`ALTER TABLE [dbo].[${tableName}] ADD CONSTRAINT [${fk.fkName}] FOREIGN KEY ([${fk.parentColumn}]) REFERENCES [dbo].[${fk.referencedTable}] ([${fk.referencedColumn}])`);
-            lines.push('GO');
+
+        // --- Build column definitions for alignment ---
+        const colParts: { name: string; type: string; suffix: string }[] = [];
+        for (const col of obj.columns) {
+            const name = `[${col.name}]`;
+
+            // Computed column: [Name] AS (expression)
+            if (col.computedDefinition) {
+                const persisted = col.isPersisted ? ' PERSISTED' : '';
+                colParts.push({ name, type: `AS ${col.computedDefinition}${persisted}`, suffix: '' });
+                continue;
+            }
+
+            const type = this.formatDataType(col);
+            let suffix = '';
+            if (col.isIdentity) { suffix += ' IDENTITY (1, 1)'; }
+            if (col.hasDefault && col.defaultValue) {
+                const dcName = col.defaultConstraintName ? `CONSTRAINT [${col.defaultConstraintName}] ` : '';
+                suffix += ` ${dcName}DEFAULT ${col.defaultValue}`;
+            }
+            suffix += col.isNullable ? ' NULL' : ' NOT NULL';
+            colParts.push({ name, type, suffix });
         }
 
-        // Triggers
+        // Calculate alignment widths
+        const maxNameLen = Math.max(...colParts.map(c => c.name.length));
+        const maxTypeLen = Math.max(...colParts.map(c => c.type.length));
+
+        // --- Build constraint lines (inline) ---
+        const constraintLines: string[] = [];
+
+        // PK inline
+        const pk = indexes.find(idx => idx.isPrimaryKey);
+        if (pk) {
+            constraintLines.push(`    CONSTRAINT [${pk.name}] PRIMARY KEY ${pk.type} (${pk.columns})`);
+        }
+
+        // FK inline
+        for (const fk of fks) {
+            let fkLine = `    CONSTRAINT [${fk.fkName}] FOREIGN KEY ([${fk.parentColumn}]) REFERENCES [dbo].[${fk.referencedTable}] ([${fk.referencedColumn}])`;
+            if (fk.deleteAction && fk.deleteAction !== 'NO_ACTION') {
+                fkLine += ` ON DELETE ${fk.deleteAction.replace(/_/g, ' ')}`;
+            }
+            if (fk.updateAction && fk.updateAction !== 'NO_ACTION') {
+                fkLine += ` ON UPDATE ${fk.updateAction.replace(/_/g, ' ')}`;
+            }
+            constraintLines.push(fkLine);
+        }
+
+        // --- Assemble CREATE TABLE ---
+        const lines: string[] = [];
+        lines.push(`CREATE TABLE [dbo].[${tableName}] (`);
+
+        const allInlineItems = [...colParts.map((c) => {
+            const padName = c.name.padEnd(maxNameLen);
+            const padType = c.type.padEnd(maxTypeLen);
+            return `    ${padName} ${padType}${c.suffix}`;
+        }), ...constraintLines];
+
+        for (let i = 0; i < allInlineItems.length; i++) {
+            const comma = i < allInlineItems.length - 1 ? ',' : '';
+            lines.push(allInlineItems[i] + comma);
+        }
+
+        lines.push(');');
+
+        // --- Non-PK indexes (separate, SSDT format, preserve existing file order) ---
+        let nonPkIndexes = indexes.filter(idx => !idx.isPrimaryKey);
+        if (existingFilePath) {
+            const existingOrder = this.getExistingIndexOrder(existingFilePath);
+            if (existingOrder.length > 0) {
+                const orderMap = new Map(existingOrder.map((name, i) => [name.toLowerCase(), i]));
+                nonPkIndexes.sort((a, b) => {
+                    const oa = orderMap.get(a.name.toLowerCase()) ?? 99999;
+                    const ob = orderMap.get(b.name.toLowerCase()) ?? 99999;
+                    return oa - ob;
+                });
+            }
+        }
+        for (const idx of nonPkIndexes) {
+            lines.push('');
+            lines.push('');
+            lines.push('GO');
+            const unique = idx.isUnique ? 'UNIQUE ' : '';
+            const filter = idx.filterDefinition ? ` WHERE ${idx.filterDefinition}` : '';
+            lines.push(`CREATE ${unique}${idx.type} INDEX [${idx.name}]`);
+            lines.push(`    ON [dbo].[${tableName}](${idx.columns})${filter};`);
+        }
+
+        // Triggers (separate)
         const triggers = this.schemaCache.getTriggers(tableName);
         for (const trig of triggers) {
             if (trig.definition) {
-                lines.push(trig.definition.trim());
+                lines.push('');
+                lines.push('');
                 lines.push('GO');
+                lines.push(trig.definition.trim());
             }
         }
 

--- a/test/schemaExporter.test.ts
+++ b/test/schemaExporter.test.ts
@@ -20,16 +20,19 @@ function assert(condition: boolean, testName: string) {
     }
 }
 
+const BOM = '\uFEFF';
+
 // Mirror of normalize + idempotent write logic from schemaExporter.ts
 function normalizeScript(script: string): string {
-    let s = script.replace(/\r\n/g, '\n').replace(/[ \t]+$/gm, '').replace(/\n+$/, '');
-    s = s + '\n';
-    // Convert to CRLF (Windows/SSDT standard)
-    return s.replace(/\n/g, '\r\n');
+    let s = script.startsWith(BOM) ? script.slice(1) : script;
+    s = s.replace(/\r\n/g, '\n').replace(/[ \t]+$/gm, '').replace(/\n+$/, '');
+    s = s + '\n\n'; // trailing blank line (SSDT standard)
+    // Convert to CRLF (Windows/SSDT standard) and prepend BOM
+    return BOM + s.replace(/\n/g, '\r\n');
 }
 
 function stripLineEndings(s: string): string {
-    return s.replace(/\r\n/g, '\n');
+    return s.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\n+$/, '\n');
 }
 
 function shouldWriteFile(filePath: string, newContent: string): boolean {
@@ -54,14 +57,14 @@ function buildExportPath(exportRoot: string, objectType: string, objectName: str
 // ─── normalizeScript ───
 console.log('\n── normalizeScript ──');
 
-assert(normalizeScript('SELECT 1\r\n') === 'SELECT 1\r\n', 'CRLF preserved');
-assert(normalizeScript('SELECT 1\n') === 'SELECT 1\r\n', 'LF to CRLF');
-assert(normalizeScript('SELECT 1  \n') === 'SELECT 1\r\n', 'trailing spaces removed');
-assert(normalizeScript('SELECT 1\t\n') === 'SELECT 1\r\n', 'trailing tabs removed');
-assert(normalizeScript('SELECT 1\n\n\n') === 'SELECT 1\r\n', 'trailing newlines collapsed');
-assert(normalizeScript('SELECT 1\r\nGO\r\n') === 'SELECT 1\r\nGO\r\n', 'multi-line CRLF');
-assert(normalizeScript('  SELECT 1  \r\n  GO  \r\n') === '  SELECT 1\r\n  GO\r\n', 'leading spaces preserved, trailing removed');
-assert(normalizeScript('SELECT 1') === 'SELECT 1\r\n', 'adds trailing CRLF if missing');
+assert(normalizeScript('SELECT 1\r\n') === BOM + 'SELECT 1\r\n\r\n', 'CRLF + BOM + trailing blank line');
+assert(normalizeScript('SELECT 1\n') === BOM + 'SELECT 1\r\n\r\n', 'LF to CRLF + BOM');
+assert(normalizeScript('SELECT 1  \n') === BOM + 'SELECT 1\r\n\r\n', 'trailing spaces removed');
+assert(normalizeScript('SELECT 1\t\n') === BOM + 'SELECT 1\r\n\r\n', 'trailing tabs removed');
+assert(normalizeScript('SELECT 1\n\n\n') === BOM + 'SELECT 1\r\n\r\n', 'trailing newlines collapsed to one blank line');
+assert(normalizeScript('SELECT 1\r\nGO\r\n') === BOM + 'SELECT 1\r\nGO\r\n\r\n', 'multi-line CRLF');
+assert(normalizeScript('  SELECT 1  \r\n  GO  \r\n') === BOM + '  SELECT 1\r\n  GO\r\n\r\n', 'leading spaces preserved, trailing removed');
+assert(normalizeScript('SELECT 1') === BOM + 'SELECT 1\r\n\r\n', 'adds trailing CRLF + BOM if missing');
 
 // ─── shouldWriteFile (idempotent) ───
 console.log('\n── shouldWriteFile ──');
@@ -69,18 +72,19 @@ console.log('\n── shouldWriteFile ──');
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'export-test-'));
 
 const newFile = path.join(tmpDir, 'new.sql');
-assert(shouldWriteFile(newFile, 'SELECT 1\r\n') === true, 'new file should write');
+assert(shouldWriteFile(newFile, BOM + 'SELECT 1\r\n') === true, 'new file should write');
 
-fs.writeFileSync(newFile, 'SELECT 1\r\n', 'utf-8');
-assert(shouldWriteFile(newFile, 'SELECT 1\r\n') === false, 'same content should skip');
+fs.writeFileSync(newFile, BOM + 'SELECT 1\r\n', 'utf-8');
+assert(shouldWriteFile(newFile, BOM + 'SELECT 1\r\n') === false, 'same content should skip');
 
-assert(shouldWriteFile(newFile, 'SELECT 2\r\n') === true, 'changed content should write');
+assert(shouldWriteFile(newFile, BOM + 'SELECT 2\r\n') === true, 'changed content should write');
 
 // LF vs CRLF difference should NOT trigger rewrite
 fs.writeFileSync(newFile, 'SELECT 1\n', 'utf-8');
-assert(shouldWriteFile(newFile, 'SELECT 1\r\n') === false, 'LF vs CRLF = same content (no rewrite)');
+assert(shouldWriteFile(newFile, BOM + 'SELECT 1\r\n') === false, 'LF vs CRLF + BOM = same content (no rewrite)');
 
-assert(shouldWriteFile(newFile, 'SELECT 1\n\n') === true, 'extra newline = different content');
+assert(shouldWriteFile(newFile, 'SELECT 1\n\n') === false, 'extra trailing newline = same content (normalized)');
+assert(shouldWriteFile(newFile, 'SELECT 2\n') === true, 'different content = should write');
 
 fs.rmSync(tmpDir, { recursive: true });
 
@@ -126,7 +130,7 @@ const e2eFile = path.join(tmpDir2, 'test.sql');
 // First write
 const script1 = 'CREATE PROC dbo.spTest\r\nAS\r\n  SELECT 1  \r\n';
 const norm1 = normalizeScript(script1);
-assert(norm1 === 'CREATE PROC dbo.spTest\r\nAS\r\n  SELECT 1\r\n', 'normalize complex script to CRLF');
+assert(norm1 === BOM + 'CREATE PROC dbo.spTest\r\nAS\r\n  SELECT 1\r\n\r\n', 'normalize complex script to BOM + CRLF + trailing blank line');
 fs.writeFileSync(e2eFile, norm1, 'utf-8');
 
 // Second write with same logical content but different whitespace
@@ -140,6 +144,99 @@ const norm3 = normalizeScript(script3);
 assert(shouldWriteFile(e2eFile, norm3) === true, 'different content after normalize = write');
 
 fs.rmSync(tmpDir2, { recursive: true });
+
+// ─── SSDT Table Format Tests ───
+console.log('\n── SSDT Table Format ──');
+
+// Mirror of formatDataType logic
+function formatDataType(col: { dataType: string; maxLength?: number | null; numericPrecision?: number; numericScale?: number; datetimePrecision?: number }): string {
+    const dt = col.dataType.toLowerCase();
+    const upper = col.dataType.toUpperCase();
+    if (['varchar', 'nvarchar', 'char', 'nchar', 'varbinary', 'binary'].includes(dt)) {
+        const len = (col.maxLength as number) === -1 ? 'MAX' : String(col.maxLength);
+        return `${upper} (${len})`;
+    }
+    if (['decimal', 'numeric'].includes(dt) && col.numericPrecision != null) {
+        return `${upper} (${col.numericPrecision}, ${col.numericScale ?? 0})`;
+    }
+    if (['datetime2', 'datetimeoffset', 'time'].includes(dt) && col.datetimePrecision != null) {
+        return `${upper} (${col.datetimePrecision})`;
+    }
+    return upper;
+}
+
+// Datatype formatting — UPPERCASE, unbracketed, with precision
+assert(formatDataType({ dataType: 'uniqueidentifier' }) === 'UNIQUEIDENTIFIER', 'uniqueidentifier uppercase');
+assert(formatDataType({ dataType: 'bit' }) === 'BIT', 'bit uppercase');
+assert(formatDataType({ dataType: 'int' }) === 'INT', 'int uppercase');
+assert(formatDataType({ dataType: 'nvarchar', maxLength: 250 }) === 'NVARCHAR (250)', 'nvarchar with length + space');
+assert(formatDataType({ dataType: 'nvarchar', maxLength: -1 }) === 'NVARCHAR (MAX)', 'nvarchar MAX');
+assert(formatDataType({ dataType: 'varchar', maxLength: 50 }) === 'VARCHAR (50)', 'varchar with length');
+assert(formatDataType({ dataType: 'datetime2', datetimePrecision: 7 }) === 'DATETIME2 (7)', 'datetime2 with precision');
+assert(formatDataType({ dataType: 'datetime2', datetimePrecision: 0 }) === 'DATETIME2 (0)', 'datetime2 precision 0');
+assert(formatDataType({ dataType: 'decimal', numericPrecision: 18, numericScale: 2 }) === 'DECIMAL (18, 2)', 'decimal with precision/scale');
+assert(formatDataType({ dataType: 'datetime' }) === 'DATETIME', 'datetime no precision');
+
+// Column definition parts
+function buildColSuffix(col: { isIdentity?: boolean; hasDefault?: boolean; defaultValue?: string; defaultConstraintName?: string; isNullable: boolean; computedDefinition?: string; isPersisted?: boolean }): string {
+    if (col.computedDefinition) {
+        return `AS ${col.computedDefinition}${col.isPersisted ? ' PERSISTED' : ''}`;
+    }
+    let suffix = '';
+    if (col.isIdentity) { suffix += ' IDENTITY (1, 1)'; }
+    if (col.hasDefault && col.defaultValue) {
+        const dcName = col.defaultConstraintName ? `CONSTRAINT [${col.defaultConstraintName}] ` : '';
+        suffix += ` ${dcName}DEFAULT ${col.defaultValue}`;
+    }
+    suffix += col.isNullable ? ' NULL' : ' NOT NULL';
+    return suffix;
+}
+
+// IDENTITY format
+assert(buildColSuffix({ isIdentity: true, isNullable: false }) === ' IDENTITY (1, 1) NOT NULL', 'IDENTITY with spaces');
+
+// DEFAULT without constraint name
+assert(buildColSuffix({ hasDefault: true, defaultValue: '(getdate())', isNullable: false }) === ' DEFAULT (getdate()) NOT NULL', 'DEFAULT without constraint name');
+
+// DEFAULT with named constraint
+assert(buildColSuffix({ hasDefault: true, defaultValue: '(getdate())', defaultConstraintName: 'DF_MyTable_AddDate', isNullable: false }) === ' CONSTRAINT [DF_MyTable_AddDate] DEFAULT (getdate()) NOT NULL', 'DEFAULT with named constraint');
+
+// Computed column
+assert(buildColSuffix({ computedDefinition: '(HOST_NAME())', isNullable: false }) === 'AS (HOST_NAME())', 'computed column');
+assert(buildColSuffix({ computedDefinition: '([Col1]+[Col2])', isPersisted: true, isNullable: false }) === 'AS ([Col1]+[Col2]) PERSISTED', 'computed column PERSISTED');
+
+// NULL / NOT NULL
+assert(buildColSuffix({ isNullable: true }) === ' NULL', 'nullable');
+assert(buildColSuffix({ isNullable: false }) === ' NOT NULL', 'not nullable');
+
+// FK cascade formatting
+function buildFkCascade(deleteAction?: string, updateAction?: string): string {
+    let suffix = '';
+    if (deleteAction && deleteAction !== 'NO_ACTION') {
+        suffix += ` ON DELETE ${deleteAction.replace(/_/g, ' ')}`;
+    }
+    if (updateAction && updateAction !== 'NO_ACTION') {
+        suffix += ` ON UPDATE ${updateAction.replace(/_/g, ' ')}`;
+    }
+    return suffix;
+}
+
+assert(buildFkCascade('NO_ACTION', 'NO_ACTION') === '', 'NO_ACTION = empty');
+assert(buildFkCascade('CASCADE', 'NO_ACTION') === ' ON DELETE CASCADE', 'ON DELETE CASCADE');
+assert(buildFkCascade('SET_NULL', 'NO_ACTION') === ' ON DELETE SET NULL', 'ON DELETE SET NULL');
+assert(buildFkCascade('SET_DEFAULT', 'NO_ACTION') === ' ON DELETE SET DEFAULT', 'ON DELETE SET DEFAULT');
+assert(buildFkCascade('CASCADE', 'CASCADE') === ' ON DELETE CASCADE ON UPDATE CASCADE', 'both cascade');
+
+// BOM in normalizeScript
+const bomScript = normalizeScript('SELECT 1');
+assert(bomScript.startsWith('\uFEFF'), 'normalizeScript adds BOM');
+assert(bomScript.charCodeAt(0) === 0xFEFF, 'BOM is first character');
+
+// Trailing blank line
+assert(bomScript.endsWith('\r\n\r\n'), 'normalizeScript ends with trailing blank line');
+
+// stripLineEndings ignores BOM + CRLF + trailing newlines
+assert(stripLineEndings('\uFEFFSELECT 1\r\n\r\n') === stripLineEndings('SELECT 1\n'), 'BOM + CRLF + trailing = same as LF');
 
 // ─── Summary ───
 console.log(`\n── Summary: ${passed} passed, ${failed} failed ──`);


### PR DESCRIPTION
## Summary

**Issue #18 — DEFAULT placeholder fix:**
- Export Schema `/*...*/` placeholder yerine gerçek DEFAULT değerini yazıyor

**Issue #17 — CRLF line ending fix:**
- `normalizeScript` CRLF + UTF-8 BOM + trailing blank line çıktı veriyor
- `writeIfChanged` karşılaştırmada BOM/LF/CRLF/trailing farkını yoksayıyor

**SSDT-compatible table export format:**
- UPPERCASE unbracketed datatypes with precision (`DATETIME2 (7)`, `NVARCHAR (250)`)
- Inline PK/FK constraints with cascade info (`ON DELETE CASCADE/SET NULL`)
- Named DEFAULT constraints (`CONSTRAINT [DcName] DEFAULT (value)`)
- Computed columns (`AS (HOST_NAME())`, `PERSISTED`)
- Filtered index WHERE clause
- Column alignment (padEnd) matching SSDT format
- Index ordering preserved from existing file
- Schema cache fully refreshed before each export

Fixes #17
Fixes #18

## Test plan

- [x] `npm run build` — başarılı
- [x] `npm test` — 244 test başarılı (+26 yeni SSDT format test)
- [x] F5 ile OCTO_CORE → OCTO_CORE_NEW export — format SSDT ile uyumlu
- [x] Tekrarlı export'ta idempotent (aynı içerik yazılmaz)
- [ ] macOS/Linux'ta export — BOM/CRLF farkı diff oluşturmamalı

🤖 Generated with [Claude Code](https://claude.com/claude-code)