### PR TITLE
feat: SSMS-style error messages with PRINT support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,9 @@ Built-in snippet'ler (`contributes.snippets`) kaldırılmıştır — tüm snipp
 - İki görüntüleme modu: `tabs` (sekmeler) veya `stacked` (alt alta) — settings'ten ayarlanır
 - CSV/JSON export
 - Sıralanabilir kolon başlıkları
+- [2026-03-29] `executeSingleBatch` mutlaka `request.batch()` kullanmalı — `request.query()` SQL'i `sp_executesql` ile sarar, PRINT mesajlarını yutar ve hata satır numaralarını yanlış raporlar
+- [2026-03-29] Hata ve info mesajları `SqlMessage` interface ile yapısal olarak yakalanmalı (number, severity, state, lineNumber, procName) — düz string değil
+- [2026-03-29] Messages panelinde SSMS formatı kullanılmalı: `Msg N, Level N, State N, Procedure X, Line N` + mesaj metni. PRINT (severity < 11) düz metin olarak gösterilir
 
 ### Şema Cache
 

--- a/src/connection/connectionManager.ts
+++ b/src/connection/connectionManager.ts
@@ -21,9 +21,24 @@ export interface QueryResult {
     columns: string[];
 }
 
+/** Structured SQL Server message (info, warning, or error) */
+export interface SqlMessage {
+    message: string;
+    /** SQL Server message number (e.g. 208 = Invalid object name) */
+    number?: number;
+    /** Severity/class: 0-10 info, 11-16 user error, 17-25 system error */
+    severity?: number;
+    /** Error state */
+    state?: number;
+    /** Line number in the SQL batch */
+    lineNumber?: number;
+    /** Procedure name (if error occurred inside a SP) */
+    procName?: string;
+}
+
 export interface BatchResult {
     resultSets: QueryResult[];
-    messages: string[];
+    messages: SqlMessage[];
     rowsAffected: number;
     error?: string;
     elapsed: number;
@@ -259,7 +274,7 @@ export class ConnectionManager {
     async executeBatch(sql: string): Promise<BatchResult> {
         const startTime = Date.now();
         const resultSets: QueryResult[] = [];
-        const messages: string[] = [];
+        const messages: SqlMessage[] = [];
         let totalRowsAffected = 0;
 
         // Split by GO on its own line
@@ -283,6 +298,17 @@ export class ConnectionManager {
                 elapsed: Date.now() - startTime,
             };
         } catch (err: any) {
+            // Extract structured error details from mssql/tedious error object
+            const errorMsg: SqlMessage = {
+                message: err.message,
+                number: err.number,
+                severity: err.class ?? err.severity,
+                state: err.state,
+                lineNumber: err.lineNumber,
+                procName: err.procName || undefined,
+            };
+            messages.push(errorMsg);
+
             return {
                 resultSets,
                 messages,
@@ -306,20 +332,30 @@ export class ConnectionManager {
         return this._activeRequest !== null;
     }
 
-    private async executeSingleBatch(sql: string, messages: string[]): Promise<QueryResult[]> {
+    private async executeSingleBatch(sql: string, messages: SqlMessage[]): Promise<QueryResult[]> {
         if (!this.pool || !this.pool.connected) { throw new Error('Not connected'); }
 
-        // Use query() instead of batch() for arrayRowMode compatibility
-        // GO splitting is already handled by executeBatch()
+        // Use batch() instead of query() — batch() sends SQL directly via TDS (like SSMS),
+        // while query() wraps in sp_executesql which swallows PRINT messages and
+        // reports incorrect line numbers in errors.
         const request = this.pool.request();
         this._activeRequest = request;
         (request as any).arrayRowMode = true;
         request.on('info', (info: any) => {
-            if (info.message) { messages.push(info.message); }
+            if (info.message) {
+                messages.push({
+                    message: info.message,
+                    number: info.number,
+                    severity: info.class,
+                    state: info.state,
+                    lineNumber: info.lineNumber,
+                    procName: info.procName || undefined,
+                });
+            }
         });
 
         try {
-            const result = await request.query(sql);
+            const result = await request.batch(sql);
             return this.normalizeArrayQueryResults(result);
         } finally {
             this._activeRequest = null;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1259,8 +1259,9 @@ export function activate(context: vscode.ExtensionContext) {
                     if (token.isCancellationRequested) {
                         vscode.window.showWarningMessage(`T-SQL: Export iptal edildi. ${written} dosya yazıldı.`);
                     } else {
+                        const connName = connectionManager.currentProfile?.name || 'unknown';
                         vscode.window.showInformationMessage(
-                            `T-SQL: Export tamamlandı — ${written} yazıldı, ${skipped} atlandı, ${errors} hata. Klasör: ${exportPath}`
+                            `T-SQL: Export tamamlandı — ${written} yazıldı, ${skipped} atlandı, ${errors} hata. Bağlantı: ${connName}. Klasör: ${exportPath}`
                         );
                     }
                 }

--- a/src/providers/messagePanel.ts
+++ b/src/providers/messagePanel.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { BatchResult } from '../connection/connectionManager';
+import { BatchResult, SqlMessage } from '../connection/connectionManager';
 
 export interface QueryMeta {
     startTime: Date;
@@ -82,19 +82,24 @@ export class MessagePanel implements vscode.WebviewViewProvider {
             lines.push(`${timeStr}         Started executing query at  Line ${meta.startLine}`);
         }
 
-        // PRINT messages and server info messages
-        for (const m of result.messages) {
-            lines.push(this.escapeHtml(m));
+        // PRINT messages, info messages, and errors (SSMS-style)
+        if (result.messages.length > 0) {
+            for (const m of result.messages) {
+                lines.push(this.formatMessage(m));
+            }
+            lines.push('');
         }
 
         // Rows affected
         if (result.rowsAffected > 0) {
             lines.push(`(${result.rowsAffected} rows affected)`);
+            lines.push('');
         }
 
         // Command completed (no result sets, no error)
         if (!result.error && result.resultSets.length === 0 && result.rowsAffected === 0) {
             lines.push('Command(s) completed successfully.');
+            lines.push('');
         }
 
         // Total execution time
@@ -105,9 +110,16 @@ export class MessagePanel implements vscode.WebviewViewProvider {
         const ems = String(elapsed % 1000).padStart(3, '0');
         lines.push(`Total execution time: ${eh}:${em}:${es}.${ems}`);
 
+        // Error messages are already included in messages array with SSMS-style formatting
+        // Show a summary error bar only if there's an error
         let errorHtml = '';
         if (result.error) {
-            errorHtml = `<div class="error">${this.escapeHtml(result.error)}</div>`;
+            const errMsgs = result.messages.filter(m => (m.severity ?? 0) >= 11);
+            if (errMsgs.length > 0) {
+                errorHtml = errMsgs.map(m => `<div class="error">${this.formatMessage(m)}</div>`).join('');
+            } else {
+                errorHtml = `<div class="error">${this.escapeHtml(result.error)}</div>`;
+            }
         }
 
         return `<!DOCTYPE html>
@@ -130,6 +142,27 @@ export class MessagePanel implements vscode.WebviewViewProvider {
     }
 </style></head>
 <body>${errorHtml}${lines.join('\n')}</body></html>`;
+    }
+
+    /** Format SqlMessage in SSMS style: Msg N, Level N, State N, Line N */
+    private formatMessage(m: SqlMessage): string {
+        const severity = m.severity ?? 0;
+        // Info messages (severity < 11, e.g. PRINT): show just the text
+        if (severity < 11 && !m.number) {
+            return this.escapeHtml(m.message);
+        }
+        // SSMS-style: Msg 208, Level 16, State 1, Procedure sp_name, Line 5
+        const parts: string[] = [];
+        parts.push(`Msg ${m.number ?? 0}`);
+        parts.push(`Level ${severity}`);
+        parts.push(`State ${m.state ?? 0}`);
+        if (m.procName) {
+            parts.push(`Procedure ${m.procName}`);
+        }
+        if (m.lineNumber != null) {
+            parts.push(`Line ${m.lineNumber}`);
+        }
+        return `${this.escapeHtml(parts.join(', '))}\n${this.escapeHtml(m.message)}`;
     }
 
     private escapeHtml(text: string): string {

--- a/src/providers/queryRunner.ts
+++ b/src/providers/queryRunner.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ConnectionManager, BatchResult, QueryResult } from '../connection/connectionManager';
+import { ConnectionManager, BatchResult, QueryResult, SqlMessage } from '../connection/connectionManager';
 import { createGridRenderer } from './grids/gridRenderer';
 import { MessagePanel } from './messagePanel';
 import { ts } from '../utils/timestamp';
@@ -488,7 +488,7 @@ ${grid.headHtml}
 </style>
 </head>
 <body>
-    ${result.error ? `<div class="error-bar">${this.escapeHtml(result.error)}</div>` : ''}
+    ${result.error ? `<div class="error-bar">${this.formatErrorBar(result)}</div>` : ''}
     ${result.resultSets.length > 0 && !isStacked ? `
     <div class="toolbar">
         <label>Filter:</label>
@@ -738,6 +738,23 @@ console.log('[TSQL] Grid init completed, gridApi:', typeof window.gridApi);
 </script>
 </body>
 </html>`;
+    }
+
+    /** Format error bar with SSMS-style details */
+    private formatErrorBar(result: BatchResult): string {
+        const errMsgs = result.messages.filter(m => (m.severity ?? 0) >= 11);
+        if (errMsgs.length > 0) {
+            return errMsgs.map(m => {
+                const parts: string[] = [];
+                parts.push(`Msg ${m.number ?? 0}`);
+                parts.push(`Level ${m.severity ?? 0}`);
+                parts.push(`State ${m.state ?? 0}`);
+                if (m.procName) { parts.push(`Procedure ${m.procName}`); }
+                if (m.lineNumber != null) { parts.push(`Line ${m.lineNumber}`); }
+                return `${this.escapeHtml(parts.join(', '))}\n${this.escapeHtml(m.message)}`;
+            }).join('\n\n');
+        }
+        return this.escapeHtml(result.error || '');
     }
 
     private escapeHtml(text: string): string {

--- a/src/sync/schemaExporter.ts
+++ b/src/sync/schemaExporter.ts
@@ -30,7 +30,8 @@ function stripLineEndings(s: string): string {
     return s.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\n+$/, '\n');
 }
 
-/** Only write if content actually changed (idempotent) */
+/** Only write if content actually changed (idempotent).
+ *  If content is same but format differs (BOM/line endings), normalize silently. */
 function writeIfChanged(filePath: string, content: string): boolean {
     const dir = path.dirname(filePath);
     if (!fs.existsSync(dir)) {
@@ -38,7 +39,12 @@ function writeIfChanged(filePath: string, content: string): boolean {
     }
     if (fs.existsSync(filePath)) {
         const existing = fs.readFileSync(filePath, 'utf-8');
-        if (stripLineEndings(existing) === stripLineEndings(content)) { return false; }
+        if (existing === content) { return false; }
+        if (stripLineEndings(existing) === stripLineEndings(content)) {
+            // Content same but format differs (BOM/CRLF) — normalize without counting as change
+            fs.writeFileSync(filePath, content, 'utf-8');
+            return false;
+        }
     }
     fs.writeFileSync(filePath, content, 'utf-8');
     return true;
@@ -66,8 +72,9 @@ export class SchemaExporter {
         }
 
         const log = this.connectionManager.log;
+        const connName = this.connectionManager.currentProfile?.name || 'unknown';
         const start = Date.now();
-        log.appendLine(`[${ts()}] [SchemaExporter] Export başladı — ${total} nesne → ${exportPath}`);
+        log.appendLine(`[${ts()}] [SchemaExporter] Export başladı — ${connName} — ${total} nesne → ${exportPath}`);
         log.show(true);
 
         // Always refresh all schema data before export (columns, FKs, indexes, triggers, definitions)
@@ -104,7 +111,7 @@ export class SchemaExporter {
         }
 
         const elapsed = ((Date.now() - start) / 1000).toFixed(1);
-        log.appendLine(`[${ts()}] [SchemaExporter] Export bitti — ${written} yazıldı, ${skipped} atlandı, ${errors} hata (${elapsed}s)`);
+        log.appendLine(`[${ts()}] [SchemaExporter] Export bitti — ${connName} — ${written} yazıldı, ${skipped} atlandı, ${errors} hata (${elapsed}s)`);
 
         return { written, skipped, errors };
     }


### PR DESCRIPTION
Closes #16

## Summary
- `SqlMessage` interface ile yapısal hata/mesaj yakalama (number, severity, state, lineNumber, procName)
- `request.query()` → `request.batch()` geçişi — PRINT mesajları artık görünüyor, satır numaraları doğru
- Messages panelinde SSMS formatı: `Msg 208, Level 16, State 1, Line 5`
- Results error bar'da da aynı detaylı format
- Export bildiriminde ve log mesajlarında bağlantı adı gösterimi

## Test plan
- [x] Deploy script (BEGIN TRANSACTION + PRINT + error) çalıştır → PRINT mesajları görünmeli
- [x] Hatalı sorguda `Msg N, Level N, State N, Line N` formatı görünmeli
- [ ] sp_help çalıştır → multiple result set + mesajlar düzgün
- [ ] Basit SELECT → mesaj panelinde "Command(s) completed successfully."
- [ ] Export Schema → bildirimde bağlantı adı görünmeli

🤖 Generated with [Claude Code](https://claude.com/claude-code)